### PR TITLE
Add bug fix for JWT restore

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -130,7 +130,7 @@ export default TokenAuthenticator.extend({
           }
           resolve(data);
         } else if (this.refreshAccessTokens) {
-          resolve(this.refreshAccessToken(token).then(() => { return data; }));
+          resolve(this.refreshAccessToken(token));
         } else {
           reject(new Error('unable to refresh token'));
         }


### PR DESCRIPTION
JWT restore's refreshAccessToken should `resolve` with the data it's
provided, not with the original data. Restoring with the original data doesn't
update the token in the store.